### PR TITLE
Update ShareButton component to change hashtags from 'forRent' to 'fo…

### DIFF
--- a/components/ShareButton.jsx
+++ b/components/ShareButton.jsx
@@ -21,14 +21,14 @@ export default function ShareButton({ meal }) {
         <FacebookShareButton
           url={shareUrl}
           quote={meal.name}
-          hashtag={`#${meal.cuisine.replace(/\s/g, '')}forRent`}
+          hashtag={`#${meal.cuisine.replace(/\s/g, '')}forBuy`}
         >
           <FacebookIcon size={40} round={true} />
         </FacebookShareButton>
         <TwitterShareButton
           url={shareUrl}
           title={meal.name}
-          hashtags={[`${meal.cuisine.replace(/\s/g, '')}forRent`]}
+          hashtags={[`${meal.cuisine.replace(/\s/g, '')}forBuy`]}
         >
           <TwitterIcon size={40} round={true} />
         </TwitterShareButton>


### PR DESCRIPTION
This pull request includes a small change to the `ShareButton` component in the `components/ShareButton.jsx` file. The change updates the hashtags used in the Facebook and Twitter share buttons to reflect a new keyword.

* [`components/ShareButton.jsx`](diffhunk://#diff-5b637640c0ee9d02d6f204d3784818397770a45dde6fa5838e9a71bcfdbe12e7L24-R31): Changed the hashtag from `#<cuisine>forRent` to `#<cuisine>forBuy` in both the Facebook and Twitter share buttons.…rBuy'